### PR TITLE
Add a translation option for date format patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ A collection of weekend events with a _dateRange_ using the [DateTools Plugin.](
         <li>
             <a href="{{ event.url }}">{{ event.title }}</a>
             <time class="dt-start" datetime="{{ event.header.event.start|date('c') }}">
-              {{ event.header.event.start|date('F j, Y') }}
+              {{ event.header.event.start|dateTranslate('F j, Y') }}
             </time>
         </li>
     {% endfor %}

--- a/events.php
+++ b/events.php
@@ -114,6 +114,7 @@ class EventsPlugin extends Plugin
 		return [
 			'onPluginsInitialized' => ['onPluginsInitialized', 0],
 			'onGetPageTemplates'   => ['onGetPageTemplates', 0],
+			'onTwigExtensions'     => ['onTwigExtensions', 0],
 		];
 	}
 
@@ -356,5 +357,17 @@ class EventsPlugin extends Plugin
 
 		// process iCalendar file(s)
 		$icalendar->process();
+	}
+
+	/**
+	 * Association with twig extensions
+	 *
+	 * @since  1.1
+	 * @return void
+	 */
+	public function onTwigExtensions()
+	{
+		require_once(__DIR__ . '/twig/DateTranslationExtension.php');
+		$this->grav['twig']->twig->addExtension(new DateTranslationExtension($this->grav));
 	}
 }

--- a/templates/calendar.html.twig
+++ b/templates/calendar.html.twig
@@ -16,10 +16,10 @@
 {% set nextMonthUrl = page.url ~ '/year:' ~ calendar.next.date|date('Y') ~ '/month:' ~ calendar.next.date|date('m') %}
 {% set currMonthUrl = page.url ~ '/year:' ~ now|date('Y') ~ '/month:' ~ now|date('m') %}
 
-{% set prevYearTitle = 'GRAV.MONTHS_OF_THE_YEAR'|ta(calendar.prevYear|date('n') - 1) ~ calendar.prevYear|date(' Y') %}
-{% set nextYearTitle = 'GRAV.MONTHS_OF_THE_YEAR'|ta(calendar.nextYear|date('n') - 1) ~ calendar.nextYear|date(' Y') %}
-{% set prevMonthTitle = 'GRAV.MONTHS_OF_THE_YEAR'|ta(calendar.prev.date|date('n') - 1) ~ calendar.prev.date|date(' Y') %}
-{% set nextMonthTitle = 'GRAV.MONTHS_OF_THE_YEAR'|ta(calendar.next.date|date('n') - 1) ~ calendar.next.date|date(' Y') %}
+{% set prevYearTitle = calendar.prevYear|dateTranslate('F') ~ calendar.prevYear|date(' Y') %}
+{% set nextYearTitle = calendar.nextYear|dateTranslate('F') ~ calendar.nextYear|date(' Y') %}
+{% set prevMonthTitle = calendar.prev.date|dateTranslate('F') ~ calendar.prev.date|date(' Y') %}
+{% set nextMonthTitle = calendar.next.date|dateTranslate('F') ~ calendar.next.date|date(' Y') %}
 
 	<section class="calendar-table">
 		<table class="calendar">
@@ -33,7 +33,7 @@
 					</th>
 					<th colspan="3" class="calendar-title">
 						<a href="{{ currMonthUrl }}" title="{{ 'PLUGIN_EVENTS.CALENDAR.TODAY'|t }}">
-						{{ 'GRAV.MONTHS_OF_THE_YEAR'|ta(calendar.date|date('n') - 1) ~ calendar.date|date(' Y') }}
+						{{ calendar.date|dateTranslate('F') ~ calendar.date|date(' Y') }}
 						</a>
 					</th>
 					<th class="calendar-buttons">
@@ -46,7 +46,7 @@
 <!--				<tr class="calendar-controls">
 					<th class="calendar-buttons" colspan="4">
 						<a href="{{ prevMonthUrl }}" class="calendar-button" title="{{ prevMonthTitle }}">&lsaquo;</a>
-						{{ 'GRAV.MONTHS_OF_THE_YEAR'|ta(calendar.date|date('n') - 1) }}
+						{{ calendar.date|dateTranslate('F') }}
 						<a href="{{ nextMonthUrl }}" class="calendar-button" title="{{ nextMonthTitle }}">&rsaquo;</a>
 					</th>
 					<th class="calendar-buttons" colspan="3">
@@ -94,7 +94,7 @@
 
 							<div class="calendar-day-details">
 							{% set title_date = calendar.month ~ '/' ~ day ~ '/' ~ calendar.year %}
-								<h4 class="calendar-day">{{ title_date|date(config.plugins.events.calendar.details.title) }}</h4>
+								<h4 class="calendar-day">{{ title_date|dateTranslate(config.plugins.events.calendar.details.title) }}</h4>
 								<ul class="calendar-day-events">
 								{% for event in calendar.events[calendar.year][calendar.month][day] %}
 									{% if event.title %}
@@ -128,7 +128,7 @@
 		{% set day = "now"|date("d") %}
 		{% set month = "now"|date("m") %}
 		{% set year = "now"|date("Y") %}
-			<h4 class="calendar-day">{{ "now"|date(config.plugins.events.calendar.details.title) }}</h4>
+			<h4 class="calendar-day">{{ "now"|dateTranslate(config.plugins.events.calendar.details.title) }}</h4>
 			<ul>
 			{% if calendar.events[year][month][day] == null %}
 				<li>{{ "PLUGIN_EVENTS.CALENDAR.NO_EVENTS"|t }}</li>

--- a/templates/partials/event_calendar_item.html.twig
+++ b/templates/partials/event_calendar_item.html.twig
@@ -1,6 +1,6 @@
 <div class="event-item-left-column">
 	<a href="{{ event.url }}" class="event-item-image-box" style="background-image: url({{ event.media.images|first.cropResize(400,400).url() }})">
-		<time class="event-item-time dt-start" datetime="{{ event.header.event.start|date("c") }}">{{ event.header.event.start|date(config.plugins.events.calendar.details.time) }}</time>
+		<time class="event-item-time dt-start" datetime="{{ event.header.event.start|date("c") }}">{{ event.header.event.start|dateTranslate(config.plugins.events.calendar.details.time) }}</time>
 	</a>
 </div>
 <div class="event-item-right-column">

--- a/templates/partials/event_item.html.twig
+++ b/templates/partials/event_item.html.twig
@@ -10,22 +10,22 @@
         <div class="event-left-column">
             <time class="event-date" datetime="{{ page.date|date("c") }}">
         {% if single == true %}{# individual content page #}
-            <span class="event-day">{{ page.header.event.start|date(config.plugins.events.event_item.day) }}.</span>
-            <span class="event-month">{{ 'GRAV.MONTHS_OF_THE_YEAR'|ta(page.header.event.start|date('m')-1) }}</span>
+            <span class="event-day">{{ page.header.event.start|dateTranslate(config.plugins.events.event_item.day) }}.</span>
+            <span class="event-month">{{ page.header.event.start|dateTranslate('m') }}</span>
             <span class="event-year">{{ page.header.event.start|date("Y") }},</span>
             <span class="event-time">
-                {{ page.header.event.start|date(config.plugins.events.event_item.start_time) }}
+                {{ page.header.event.start|dateTranslate(config.plugins.events.event_item.start_time) }}
                 {% if page.header.event.end %}
-                    &ndash;{{ page.header.event.end|date(config.plugins.events.event_item.end_time) }}
+                    &ndash;{{ page.header.event.end|dateTranslate(config.plugins.events.event_item.end_time) }}
                 {% endif %}
             </span>
 
         {% else %}{# main listing page #}
-            <span class="event-day">{{ page.header.event.start|date(config.plugins.events.event_item.day) }}</span>
-            <span class="event-month">{{ 'GRAV.MONTHS_OF_THE_YEAR'|ta(page.header.event.start|date('m')-1)|slice(0,3) }}</span>
-            <!--<span class="event-month">{{ page.header.event.start|date(config.plugins.events.event_item.month) }}</span>-->
+            <span class="event-day">{{ page.header.event.start|dateTranslate(config.plugins.events.event_item.day) }}</span>
+            <span class="event-month">{{ page.header.event.start|dateTranslate('M') }}</span>
+            <!--<span class="event-month">{{ page.header.event.start|dateTranslate(config.plugins.events.event_item.month) }}</span>-->
             <span class="event-time">
-                {{ page.header.event.start|date(config.plugins.events.event_item.start_time) }}&ndash;{{ page.header.event.end|date(config.plugins.events.event_item.end_time) }}
+                {{ page.header.event.start|dateTranslate(config.plugins.events.event_item.start_time) }}&ndash;{{ page.header.event.end|dateTranslate(config.plugins.events.event_item.end_time) }}
             </span>
             <span class="event-year">{{ page.header.event.start|date("Y") }}</span>
         {% endif %}

--- a/templates/partials/event_meta.html.twig
+++ b/templates/partials/event_meta.html.twig
@@ -8,6 +8,6 @@
 {% endif %}
 
 {% if page.header.event.until is defined %}
-    <span>until {{ page.header.event.until|date('F j, Y') }}</span>
+    <span>until {{ page.header.event.until|dateTranslate('F j, Y') }}</span>
 {% endif %}
 </p>

--- a/templates/partials/events_sidebar.html.twig
+++ b/templates/partials/events_sidebar.html.twig
@@ -38,11 +38,11 @@
         {% set date_header = event.header.event.start|date('F d') %}
         {% if date_header != current_header %}
         <li class="event-day">
-            <span>{{ event.header.event.start|date(config.plugins.events.event_sidebar.header) }}</span>
+            <span>{{ event.header.event.start|dateTranslate(config.plugins.events.event_sidebar.header) }}</span>
         </li>
         {% endif %}
         <li class="event-item">
-            <time datetime="{{ event.header.event.start|date("c") }}">{{ event.header.event.start|date(config.plugins.events.event_sidebar.time)}}</time>
+            <time datetime="{{ event.header.event.start|date("c") }}">{{ event.header.event.start|dateTranslate(config.plugins.events.event_sidebar.time)}}</time>
             <a href="{{ event.url }}" class="u-url p-name">{{ event.title }}</a>
         </li>
         {% set current_header = event.header.event.start|date('F d') %}

--- a/twig/DateTranslationExtension.php
+++ b/twig/DateTranslationExtension.php
@@ -1,0 +1,138 @@
+<?php
+namespace Grav\Plugin;
+
+use Grav\Common\Grav;
+
+/**
+ * DateTranslationExtension 
+ *
+ * DateTranslationExtension adds a filter and a function `dateTranslate` to
+ * twig templating. The extension is based on the already existing `date`
+ * function and filter`.
+ * 
+ * In twig `dateTranslate` is used similar to `date` function and filter,
+ * only the result differs in that textual months and days in a date are
+ * translated using the *translate array function* on `GRAV.DAYS_OF_THE_WEEK`
+ * and GRAV.MONTHS_OF_THE_YEAR:
+ *
+ * ```
+ * Filter  : {{ "2020-01-01"| dateTranslate("l, F j, Y")}}
+ * Function: {{ dateTranslate("2020-01-01", "l, F j, Y")}}
+ * ```
+ * for English results in
+ * ```
+ * Filter  : Wednesday, January 01, 2020
+ * Function: Wednesday, January 01, 2020
+ * ```
+ * which for e.g. German results in
+ * ```
+ * Filter  : Mittwoch, Januar 01, 2020
+ * Function: Mittwoch, Januar 01, 2020
+ * ```
+ *
+ * PHP version 5.6+
+ *
+ * @since      1.1.0
+ */
+class DateTranslationExtension extends \Twig_Extension
+{
+	/**
+	 * Returns this extensions name
+	 */
+	public function getName()
+	{
+		return 'DateTranslationExtension';
+	}
+
+	/**
+	 * Returns the Functions that will be exposed to twig templating
+	 */
+	public function getFunctions()
+	{
+		return [
+			new \Twig_SimpleFunction(
+				'dateTranslate',
+				[$this, 'dateTranslate'],
+				['needs_environment' => true]
+			)
+		];
+	}
+
+	/**
+	 * Returns the Filters that will be exposed to twig templating
+	 */
+	public function getFilters()
+	{
+		return [
+			new \Twig_SimpleFilter(
+				'dateTranslate',
+				[$this, 'dateTranslate'],
+				['needs_environment' => true]
+			)
+		];
+	}
+
+
+	/**
+	 * Translates textual days and years of a date string under
+	 * formating by fragmenting the given date-pattern and converting
+	 * the fragments individually to segments of the date. Text parts
+	 * are also translated into the target language as specified in the
+	 * page's frontmatter or system settings and passed by twig.
+	 * 
+	 * The implementation makes use of the *translate array function*
+	 * `ta` with GRAV.DAYS_OF_THE_WEEK and GRAV.MONTHS_OF_THE_YEAR.
+	 * 
+	 * @param env The twig environment as required by
+	 * 	`twig_date_format_filter`
+	 * @param date The date time-stamp to format
+	 * @param datePattern The date format pattern
+	 * 
+	 * @return The translated date string
+	 */
+	public function dateTranslate(\Twig_Environment $env, $date, $datePattern)
+	{
+		$dateFunction = function ($format) use ($env, $date) {
+			// php `twig_date_format_filter` represents twig's `|date`
+			return twig_date_format_filter($env, $date, $format);
+		};
+
+		$dateString = '';
+		$tokens = preg_split('/([DlMF])/', preg_quote($datePattern), 0, PREG_SPLIT_DELIM_CAPTURE);
+		foreach ($tokens as $t) {
+			switch ($t) {
+				case 'D':
+					// A textual representation of a day, three letters: Mon through Sun
+					$dateString .= substr($this->translateDay($dateFunction), 0, 3);
+					break;
+				case 'l':
+					// A full textual representation of the day of the week: Sunday through Saturday
+					$dateString .= $this->translateDay($dateFunction);
+					break;
+				case 'M':
+					// A short textual representation of a month, three letters: Jan through Dec
+					$dateString .= substr($this->translateMonth($dateFunction), 0, 3);
+					break;
+				case 'F':
+					// A full textual representation of a month, such as January or March: January through December
+					$dateString .= $this->translateMonth($dateFunction);
+					break;
+				default:
+					$dateString .= $dateFunction($t);
+			}
+		}
+		return $dateString;
+	}
+
+	private function translateDay($dateFunction)
+	{
+		// php `translateArray` represents twig's `|ta`
+		return Grav::instance()['language']->translateArray('GRAV.DAYS_OF_THE_WEEK', ($dateFunction('w') + 6) % 7);
+	}
+
+	private function translateMonth($dateFunction)
+	{
+		// php `translateArray` represents twig's `|ta`
+		return Grav::instance()['language']->translateArray('GRAV.MONTHS_OF_THE_YEAR', $dateFunction('n') - 1);
+	}
+}


### PR DESCRIPTION
Some date strings are not translated. This pull request introduces a Function and Filter `dateTranslate` that translates date formatted strings and already applies it where appropriate.