### PR TITLE
Fix calendar's day details initial view

### DIFF
--- a/templates/calendar.html.twig
+++ b/templates/calendar.html.twig
@@ -125,8 +125,8 @@
 
 	<section class="calendar-details">
 		<div class="calendar-day-details">
-		{% set day = "now"|date("d") %}
-		{% set month = "now"|date("m") %}
+		{% set day = "now"|date("j") %}
+		{% set month = "now"|date("n") %}
 		{% set year = "now"|date("Y") %}
 			<h4 class="calendar-day">{{ "now"|date(config.plugins.events.calendar.details.title) }}</h4>
 			<ul>


### PR DESCRIPTION
The calendar's day details don't show the details of the current day. This pull request formats current the date such that it will be interpreted as a number and correct array index.