### PR TITLE
'Variable not defined' error in PHP 8+

### DIFF
--- a/classes/eventsProcessor.php
+++ b/classes/eventsProcessor.php
@@ -524,6 +524,9 @@ class EventsProcessor
 		/**
 		 * Calculate the iteration count depending on frequency set
 		 */
+		
+		$count = 0;
+		
 		switch ( $freq ) {
 			case 'daily':
 				$count = $until->diffInDays($start);


### PR DESCRIPTION
If you use the event plugin with PHP 8+ you get an undefined variable error.